### PR TITLE
Fix code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ pyyaml==3.13
 trafaret-config==2.0.2
 trafaret==1.2.0
 yarl==1.3.0               # via aiohttp
+
+argon2-cffi==23.1.0

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -1,4 +1,4 @@
-from hashlib import md5
+from argon2 import PasswordHasher
 from typing import NamedTuple, Optional
 
 from aiopg import Connection
@@ -38,4 +38,8 @@ class User(NamedTuple):
             return User.from_raw(await cur.fetchone())
 
     def check_password(self, password: str):
-        return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        ph = PasswordHasher()
+        try:
+            return ph.verify(self.pwd_hash, password)
+        except:
+            return False


### PR DESCRIPTION
Fixes [https://github.com/lreis09uc/dvpwa/security/code-scanning/1](https://github.com/lreis09uc/dvpwa/security/code-scanning/1)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure algorithm suitable for password hashing. One of the best options is to use the `argon2` algorithm, which is designed to be computationally expensive and includes a per-password salt by default.

The changes required include:
1. Importing the `PasswordHasher` class from the `argon2` library.
2. Replacing the `check_password` method to use `PasswordHasher` for verifying passwords.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
